### PR TITLE
Add unit_fraction notation kind for unit(x) as x/‖x‖

### DIFF
--- a/docs/adrs/048-unit-fraction-notation.md
+++ b/docs/adrs/048-unit-fraction-notation.md
@@ -1,0 +1,44 @@
+---
+status: accepted
+date: 2026-03-31
+deciders: edouard
+---
+
+# ADR-048: unit_fraction Notation Kind
+
+## Context and Problem Statement
+
+The default `unit()` rendering uses a hat accent (`\hat{B}` / `B̂`) for
+single-glyph names. This is visually clean but means `display()` can't
+show the intermediate step — the accent form is identical to the name,
+so it gets deduplicated.
+
+Users want to see `\hat{B} = \frac{B}{\lVert B \rVert} = e_{12}` in
+notebooks, which requires the expression form to differ from the name.
+
+## Decision Outcome
+
+Add a `unit_fraction` notation kind that renders `unit(x)` as `x/‖x‖`
+(unicode) or `\frac{x}{\lVert x \rVert}` (LaTeX). Users opt in per-algebra:
+
+```python
+from galaga.notation import NotationRule
+alg.notation.set("Unit", "latex", NotationRule(kind="unit_fraction"))
+alg.notation.set("Unit", "unicode", NotationRule(kind="unit_fraction"))
+```
+
+### Tactical, Not Generic
+
+This is a purpose-built notation kind for `unit()`, not a generic
+"fraction with transformed denominator" system. A generic approach would
+support arbitrary denominator transforms (`x/f(x)`) but adds complexity
+for a single use case. If more fraction-with-transform patterns emerge,
+generalise then.
+
+### Consequences
+
+- Good, because `display()` can show the fraction form as a distinct step
+- Good, because it's opt-in — default accent behaviour unchanged
+- Good, because compound expressions auto-wrap: `(a + b)/‖a + b‖`
+- Neutral, because it's a new notation kind (increases the kind vocabulary)
+- Acceptable, because the tactical scope is documented for future reference

--- a/packages/galaga/galaga/latex_build.py
+++ b/packages/galaga/galaga/latex_build.py
@@ -164,6 +164,12 @@ def _build(node: Expr, n: Notation) -> LNode:
         sep = " " if rule.symbol.startswith("\\") and rule.symbol[-1:].isalpha() else ""
         return Seq([Text(rule.symbol), inner], sep=sep)
 
+    # Unit fraction: \frac{x}{\lVert x \rVert}
+    if rule.kind == "unit_fraction" and hasattr(node, "x"):
+        num = _wp(_build(node.x, n), node.x, 70)
+        den = _build(Norm(node.x), n)
+        return Frac(num, den)
+
     # Accent (combining diacritical or wide accent)
     if rule.kind == "accent" and hasattr(node, "x"):
         # Use narrow accent (\tilde) for single-glyph names, wide (\widetilde) otherwise.

--- a/packages/galaga/galaga/render.py
+++ b/packages/galaga/galaga/render.py
@@ -252,6 +252,11 @@ def render(node: Expr, notation: Notation | None = None) -> str:
     if rule.kind == "prefix" and hasattr(node, "x"):
         return f"{rule.symbol}{_w(render(node.x, n), node.x, 95)}"
 
+    # Unit fraction: x/‖x‖
+    if rule.kind == "unit_fraction" and hasattr(node, "x"):
+        inner = render(node.x, n)
+        return f"{_w(inner, node.x, 70)}/‖{render(node.x, n)}‖"
+
     # Accent (combining char for atoms, prefix fallback for compounds)
     if rule.kind == "accent" and hasattr(node, "x"):
         inner = render(node.x, n)

--- a/packages/galaga/tests/test_notation.py
+++ b/packages/galaga/tests/test_notation.py
@@ -699,3 +699,50 @@ class TestFunctionalShortPreset:
         """\\operatorname{gp} in LaTeX."""
         a, b = ab
         assert r"\operatorname{gp}" in (a * b).latex()
+
+
+class TestUnitFractionNotation:
+    """unit_fraction notation kind renders as x/‖x‖."""
+
+    def test_unicode(self):
+        """B/‖B‖ in unicode."""
+        from galaga.notation import NotationRule
+
+        alg = Algebra((1, 1, 1))
+        alg.notation.set("Unit", "unicode", NotationRule(kind="unit_fraction"))
+        e1, e2, _ = alg.basis_vectors(lazy=True)
+        B = (e1 ^ e2).name("B")
+        assert str(unit(B)) == "B/‖B‖"
+
+    def test_latex(self):
+        r"""\\frac{B}{\\lVert B \\rVert} in LaTeX."""
+        from galaga.notation import NotationRule
+
+        alg = Algebra((1, 1, 1))
+        alg.notation.set("Unit", "latex", NotationRule(kind="unit_fraction"))
+        e1, e2, _ = alg.basis_vectors(lazy=True)
+        B = (e1 ^ e2).name("B")
+        assert unit(B).latex() == r"\frac{B}{\lVert B \rVert}"
+
+    def test_compound_wraps(self):
+        """Compound expression gets parenthesised in numerator."""
+        from galaga.notation import NotationRule
+
+        alg = Algebra((1, 1, 1))
+        alg.notation.set("Unit", "unicode", NotationRule(kind="unit_fraction"))
+        e1, e2, _ = alg.basis_vectors(lazy=True)
+        a, b = e1.name("a"), e2.name("b")
+        assert str(unit(a + b)) == "(a + b)/‖a + b‖"
+
+    def test_display_shows_fraction(self):
+        """display() shows fraction form distinct from hat name."""
+        from galaga.notation import NotationRule
+
+        alg = Algebra((1, 1, 1))
+        alg.notation.set("Unit", "latex", NotationRule(kind="unit_fraction"))
+        e1, e2, _ = alg.basis_vectors(lazy=True)
+        B = (e1 ^ e2).name("B")
+        Bhat = unit(B).name(latex=r"\hat{B}")
+        d = Bhat.display().latex()
+        assert r"\hat{B}" in d
+        assert r"\frac{B}" in d


### PR DESCRIPTION
## Summary

Adds a new `unit_fraction` notation kind that renders `unit(x)` as
`x/‖x‖` (unicode) or `\frac{x}{\lVert x \rVert}` (LaTeX).

### Motivation

The default accent rendering (`\hat{B}`) is identical to a named unit
vector's display name, so `display()` deduplicates them and can't show
the intermediate step. The fraction form is distinct, enabling:

```
\hat{B} = \frac{B}{\lVert B \rVert} = e_{12}
```

### Usage

```python
from galaga.notation import NotationRule
alg.notation.set('Unit', 'latex', NotationRule(kind='unit_fraction'))
alg.notation.set('Unit', 'unicode', NotationRule(kind='unit_fraction'))
```

Default accent behaviour is unchanged — this is opt-in.

### Stats

- 1363 tests pass (4 new)
- ADR-048: documents this as a tactical approach, not a generic solution