### PR TITLE
LaTeX scientific notation via LNodes and Notation.scientific setting

### DIFF
--- a/docs/adrs/050-latex-scientific-notation.md
+++ b/docs/adrs/050-latex-scientific-notation.md
@@ -33,13 +33,6 @@ A regex substitution (`_latex_coeff`) runs on formatted coefficient strings,
 driven by the algebra's notation setting. This is a string-level transform,
 not an LNode pipeline operation.
 
-### Future Improvement
-
-Move coefficient rendering into the LNode pipeline so scientific notation
-produces structured nodes (`Seq`, `Sup`, `Text`) instead of formatted strings.
-This would eliminate the regex and let the rewrite pass handle context-dependent
-transforms (e.g. different rendering in superscripts vs normal context).
-
 ### Consequences
 
 - Good, because scientific notation renders correctly in LaTeX by default

--- a/docs/adrs/050-latex-scientific-notation.md
+++ b/docs/adrs/050-latex-scientific-notation.md
@@ -4,7 +4,7 @@ date: 2026-04-03
 deciders: edouard
 ---
 
-# ADR-050: LaTeX Scientific Notation via Regex Rewrite
+# ADR-050: LaTeX Scientific Notation via Notation Setting
 
 ## Context and Problem Statement
 
@@ -14,32 +14,36 @@ making it look like subtraction rather than an exponent.
 
 ## Decision Outcome
 
-Apply a regex substitution (`_latex_coeff`) to coefficient strings in the
-LaTeX rendering path, converting `1.2e-06` to `1.2 \times 10^{-6}`.
+Add a `scientific` property to `Notation` that controls how scientific
+notation is rendered in LaTeX. Three styles:
 
-### Why Regex (Tactical)
+| Style | Output | Usage |
+|---|---|---|
+| `"times"` (default) | `1.2 \times 10^{-6}` | Standard LaTeX |
+| `"cdot"` | `1.2 \cdot 10^{-6}` | Alternative convention |
+| `"raw"` | `1.2e-06` | No conversion (for debugging) |
 
-The proper solution would be to produce structured LNodes (`Seq`, `Sup`,
-`Text`) for scientific notation, so the three-phase render pipeline handles
-it like any other expression. However, coefficient rendering currently
-bypasses the LNode pipeline entirely — it's string concatenation in
-`Multivector.latex()`. Moving it into the pipeline is a larger refactor.
+```python
+alg.notation.scientific = "cdot"  # switch style
+```
 
-The regex is a bridge: it runs after `format()` produces the string but
-before it's assembled into the final LaTeX. It handles all standard Python
-scientific notation formats (`e`, `E`, `+`, `-`).
+### Implementation
+
+A regex substitution (`_latex_coeff`) runs on formatted coefficient strings,
+driven by the algebra's notation setting. This is a string-level transform,
+not an LNode pipeline operation.
 
 ### Future Improvement
 
-Move coefficient rendering into the LNode pipeline:
-1. A concrete MV's coefficients would produce `Seq([Text("1.2"), Text(r" \times "), Sup(Text("10"), Text("-6"))])` instead of `Text("1.2e-06")`
-2. The existing emit/rewrite passes handle it from there
-3. The regex becomes unnecessary
+Move coefficient rendering into the LNode pipeline so scientific notation
+produces structured nodes (`Seq`, `Sup`, `Text`) instead of formatted strings.
+This would eliminate the regex and let the rewrite pass handle context-dependent
+transforms (e.g. different rendering in superscripts vs normal context).
 
 ### Consequences
 
-- Good, because `1.2 \times 10^{-6}` renders correctly in all LaTeX contexts
-- Good, because it handles both default `:g` and explicit `coeff_format` paths
+- Good, because scientific notation renders correctly in LaTeX by default
+- Good, because the style is configurable per-algebra via Notation
+- Good, because `"raw"` mode available for debugging
 - Neutral, because the regex is simple and well-tested
-- Bad, because it's a string-level hack outside the render tree architecture
-- Acceptable, because the scope is narrow and the future path is documented
+- Bad, because it's a string-level transform outside the render tree

--- a/docs/adrs/050-latex-scientific-notation.md
+++ b/docs/adrs/050-latex-scientific-notation.md
@@ -4,7 +4,7 @@ date: 2026-04-03
 deciders: edouard
 ---
 
-# ADR-050: LaTeX Scientific Notation via Notation Setting
+# ADR-050: LaTeX Scientific Notation via LNodes and Notation Setting
 
 ## Context and Problem Statement
 
@@ -14,14 +14,18 @@ making it look like subtraction rather than an exponent.
 
 ## Decision Outcome
 
-Add a `scientific` property to `Notation` that controls how scientific
-notation is rendered in LaTeX. Three styles:
+Coefficient rendering in `Multivector.latex()` now produces LNodes
+(`Text`, `Seq`, `Sup`) instead of raw strings. Scientific notation like
+`1.2e-06` becomes `Seq([Text("1.2 \\times "), Sup(Text("10"), Text("-6"))])`,
+which emits as `1.2 \times 10^{-6}`.
+
+The style is controlled by `Notation.scientific`:
 
 | Style | Output | Usage |
 |---|---|---|
 | `"times"` (default) | `1.2 \times 10^{-6}` | Standard LaTeX |
 | `"cdot"` | `1.2 \cdot 10^{-6}` | Alternative convention |
-| `"raw"` | `1.2e-06` | No conversion (for debugging) |
+| `"raw"` | `1.2e-06` | No conversion |
 
 ```python
 alg.notation.scientific = "cdot"  # switch style
@@ -29,17 +33,15 @@ alg.notation.scientific = "cdot"  # switch style
 
 ### Implementation
 
-A regex substitution (`_latex_coeff`) runs on formatted coefficient strings,
-driven by the algebra's notation setting. This is a string-level transform,
-not an LNode pipeline operation.
+- `_sci_lnode()` parses a formatted number string and returns an LNode tree
+- `_coeff_lnode()` builds a complete coefficient × blade term as an LNode
+- `Multivector.latex()` builds LNodes per term, then emits them
+- The `Sup(Text("10"), Text("-6"))` is a proper render tree node, handled
+  by the existing emit pipeline
 
 ### Consequences
 
-- Good, because scientific notation renders correctly in LaTeX by default
+- Good, because scientific notation is rendered via the LNode tree, not regex
 - Good, because the style is configurable per-algebra via Notation
-- Good, because `"raw"` mode available for debugging
-- Neutral, because the regex is simple, well-tested, and produces correct output
-- Neutral, because coefficient rendering is a separate path from the symbolic
-  render tree — moving it into the LNode pipeline would require rewriting
-  `Multivector.latex()` to produce LNodes instead of strings. Not planned
-  unless the coefficient path needs context-dependent transforms.
+- Good, because no special-case string transforms to maintain
+- Good, because new coefficient formatting paths automatically get correct rendering

--- a/docs/adrs/050-latex-scientific-notation.md
+++ b/docs/adrs/050-latex-scientific-notation.md
@@ -45,5 +45,8 @@ transforms (e.g. different rendering in superscripts vs normal context).
 - Good, because scientific notation renders correctly in LaTeX by default
 - Good, because the style is configurable per-algebra via Notation
 - Good, because `"raw"` mode available for debugging
-- Neutral, because the regex is simple and well-tested
-- Bad, because it's a string-level transform outside the render tree
+- Neutral, because the regex is simple, well-tested, and produces correct output
+- Neutral, because coefficient rendering is a separate path from the symbolic
+  render tree — moving it into the LNode pipeline would require rewriting
+  `Multivector.latex()` to produce LNodes instead of strings. Not planned
+  unless the coefficient path needs context-dependent transforms.

--- a/packages/galaga/galaga/algebra.py
+++ b/packages/galaga/galaga/algebra.py
@@ -512,29 +512,44 @@ class Algebra:
 import re as _re
 
 
-def _latex_coeff(s: str, notation=None) -> str:
-    """Convert a formatted coefficient string to LaTeX-safe form.
+def _sci_lnode(s: str, style: str):
+    """Convert a formatted number string to an LNode, handling scientific notation.
 
-    Uses the notation's scientific style setting:
-    - 'times': 1.2e-06 → 1.2 \\times 10^{-6}
-    - 'cdot':  1.2e-06 → 1.2 \\cdot 10^{-6}
-    - 'raw':   1.2e-06 → 1.2e-06 (no conversion)
+    Returns an LNode (Text, or Seq with Sup for scientific notation).
     """
-    if notation is not None:
-        style = notation.scientific
-    else:
-        style = "times"
+    from galaga.latex_nodes import Seq, Sup, Text
+
     if style == "raw":
-        return s
+        return Text(s)
     m = _re.match(r"^(-?)(\d+\.?\d*)[eE]([+-]?\d+)$", s)
     if not m:
-        return s
+        return Text(s)
     sign, mantissa, exp = m.groups()
     exp_int = int(exp)
     sep = r" \times " if style == "times" else r" \cdot "
     if mantissa in ("1", "1."):
-        return rf"{sign}10^{{{exp_int}}}"
-    return rf"{sign}{mantissa}{sep}10^{{{exp_int}}}"
+        return Seq([Text(sign), Sup(Text("10"), Text(str(exp_int)))])
+    return Seq([Text(f"{sign}{mantissa}{sep}"), Sup(Text("10"), Text(str(exp_int)))])
+
+
+def _coeff_lnode(c: float, blade: str, coeff_format: str | None, style: str):
+    """Build an LNode for a single coefficient × blade term."""
+    from galaga.latex_nodes import Seq, Text
+
+    if coeff_format:
+        formatted = format(c, coeff_format)
+        coeff_node = _sci_lnode(formatted, style)
+        if blade == "":
+            return coeff_node
+        return Seq([coeff_node, Text(f" {blade}")])
+    else:
+        formatted = f"{c:g}"
+        if blade == "":
+            return _sci_lnode(formatted, style)
+        if np.isclose(abs(c), 1.0):
+            return Text(blade if c > 0 else f"-{blade}")
+        coeff_node = _sci_lnode(formatted, style)
+        return Seq([coeff_node, Text(f" {blade}")])
 
 
 class _DisplayResult:
@@ -1156,9 +1171,12 @@ class Multivector:
         elif self._is_lazy and self._expr is not None and coeff_format is None:
             raw = _render.render_latex(self._expr, self.algebra._notation)
         else:
-            # Eager anonymous → existing coefficient rendering
+            # Eager anonymous → coefficient rendering via LNodes
+            from galaga.latex_emit import emit
+
             alg = self.algebra
-            terms = []
+            style = alg._notation.scientific
+            term_nodes = []
             for i in range(alg.dim):
                 c = self.data[i]
                 if coeff_format:
@@ -1167,29 +1185,18 @@ class Multivector:
                 else:
                     if abs(c) < 1e-12:
                         continue
-                name = alg._blade_latex(i)
-                if coeff_format:
-                    formatted_c = _latex_coeff(format(c, coeff_format), self.algebra._notation)
-                    if name == "":
-                        terms.append(formatted_c)
-                    else:
-                        terms.append(f"{formatted_c} {name}")
-                else:
-                    if name == "":
-                        terms.append(_latex_coeff(f"{c:g}", self.algebra._notation))
-                    elif np.isclose(abs(c), 1.0):
-                        terms.append(name if c > 0 else f"-{name}")
-                    else:
-                        terms.append(f"{_latex_coeff(f'{c:g}', self.algebra._notation)} {name}")
-            if not terms:
+                blade = alg._blade_latex(i)
+                term_nodes.append(_coeff_lnode(c, blade, coeff_format, style))
+            if not term_nodes:
                 raw = format(0.0, coeff_format) if coeff_format else "0"
             else:
-                raw = terms[0]
-                for t in terms[1:]:
-                    if t.startswith("-"):
-                        raw += " - " + t[1:]
+                raw = emit(term_nodes[0])
+                for tn in term_nodes[1:]:
+                    s = emit(tn)
+                    if s.startswith("-"):
+                        raw += " - " + s[1:]
                     else:
-                        raw += " + " + t
+                        raw += " + " + s
         if wrap == "$":
             return f"${raw}$"
         if wrap == "$$":

--- a/packages/galaga/galaga/algebra.py
+++ b/packages/galaga/galaga/algebra.py
@@ -512,19 +512,29 @@ class Algebra:
 import re as _re
 
 
-def _latex_coeff(s: str) -> str:
+def _latex_coeff(s: str, notation=None) -> str:
     """Convert a formatted coefficient string to LaTeX-safe form.
 
-    Replaces scientific notation like '1.2e-06' with '1.2 \\times 10^{-6}'.
+    Uses the notation's scientific style setting:
+    - 'times': 1.2e-06 → 1.2 \\times 10^{-6}
+    - 'cdot':  1.2e-06 → 1.2 \\cdot 10^{-6}
+    - 'raw':   1.2e-06 → 1.2e-06 (no conversion)
     """
+    if notation is not None:
+        style = notation.scientific
+    else:
+        style = "times"
+    if style == "raw":
+        return s
     m = _re.match(r"^(-?)(\d+\.?\d*)[eE]([+-]?\d+)$", s)
-    if m:
-        sign, mantissa, exp = m.groups()
-        exp_int = int(exp)
-        if mantissa in ("1", "1."):
-            return rf"{sign}10^{{{exp_int}}}"
-        return rf"{sign}{mantissa} \times 10^{{{exp_int}}}"
-    return s
+    if not m:
+        return s
+    sign, mantissa, exp = m.groups()
+    exp_int = int(exp)
+    sep = r" \times " if style == "times" else r" \cdot "
+    if mantissa in ("1", "1."):
+        return rf"{sign}10^{{{exp_int}}}"
+    return rf"{sign}{mantissa}{sep}10^{{{exp_int}}}"
 
 
 class _DisplayResult:
@@ -1159,18 +1169,18 @@ class Multivector:
                         continue
                 name = alg._blade_latex(i)
                 if coeff_format:
-                    formatted_c = _latex_coeff(format(c, coeff_format))
+                    formatted_c = _latex_coeff(format(c, coeff_format), self.algebra._notation)
                     if name == "":
                         terms.append(formatted_c)
                     else:
                         terms.append(f"{formatted_c} {name}")
                 else:
                     if name == "":
-                        terms.append(_latex_coeff(f"{c:g}"))
+                        terms.append(_latex_coeff(f"{c:g}", self.algebra._notation))
                     elif np.isclose(abs(c), 1.0):
                         terms.append(name if c > 0 else f"-{name}")
                     else:
-                        terms.append(f"{_latex_coeff(f'{c:g}')} {name}")
+                        terms.append(f"{_latex_coeff(f'{c:g}', self.algebra._notation)} {name}")
             if not terms:
                 raw = format(0.0, coeff_format) if coeff_format else "0"
             else:

--- a/packages/galaga/galaga/notation.py
+++ b/packages/galaga/galaga/notation.py
@@ -159,10 +159,27 @@ _DEFAULTS: dict[str, dict[str, NotationRule]] = {
 class Notation:
     """Configurable rendering rules for all GA operations."""
 
+    # Scientific notation styles for LaTeX coefficient rendering
+    SCI_TIMES = "times"  # 1.2 \times 10^{-6}
+    SCI_CDOT = "cdot"  # 1.2 \cdot 10^{-6}
+    SCI_RAW = "raw"  # 1.2e-06 (no conversion)
+
     def __init__(self):
         self._rules: dict[str, dict[str, NotationRule]] = {}
         for name, fmts in _DEFAULTS.items():
             self._rules[name] = {k: copy.copy(v) for k, v in fmts.items()}
+        self._scientific: str = self.SCI_TIMES
+
+    @property
+    def scientific(self) -> str:
+        """Scientific notation style for LaTeX: 'times', 'cdot', or 'raw'."""
+        return self._scientific
+
+    @scientific.setter
+    def scientific(self, value: str):
+        if value not in (self.SCI_TIMES, self.SCI_CDOT, self.SCI_RAW):
+            raise ValueError(f"Unknown scientific notation style: {value!r}")
+        self._scientific = value
 
     def get(self, node_name: str, fmt: str) -> NotationRule | None:
         """Get the rendering rule for a node type name and format."""
@@ -183,6 +200,7 @@ class Notation:
         n._rules = {}
         for name, fmts in self._rules.items():
             n._rules[name] = {k: copy.copy(v) for k, v in fmts.items()}
+        n._scientific = self._scientific
         return n
 
     @staticmethod

--- a/packages/galaga/tests/test_scalar_helpers.py
+++ b/packages/galaga/tests/test_scalar_helpers.py
@@ -143,3 +143,47 @@ class TestScalarConstants:
         """pi/2 renders symbolically."""
         half_pi = alg.pi / alg.scalar(2).name("2")
         assert r"\pi" in half_pi.latex()
+
+
+class TestScientificNotationStyle:
+    """Notation.scientific controls LaTeX scientific notation rendering."""
+
+    def test_default_is_times(self, alg):
+        """Default style is 'times'."""
+        assert alg.notation.scientific == "times"
+
+    def test_times_style(self, alg):
+        """'times' renders as \\times."""
+        e1, _, _ = alg.basis_vectors()
+        result = (1.2e-6 * e1).latex()
+        assert r"\times 10^{-6}" in result
+
+    def test_cdot_style(self, alg):
+        """'cdot' renders as \\cdot."""
+        alg.notation.scientific = "cdot"
+        e1, _, _ = alg.basis_vectors()
+        result = (1.2e-6 * e1).latex()
+        assert r"\cdot 10^{-6}" in result
+
+    def test_raw_style(self, alg):
+        """'raw' passes through Python notation."""
+        alg.notation.scientific = "raw"
+        e1, _, _ = alg.basis_vectors()
+        result = (1.2e-6 * e1).latex()
+        assert "e-06" in result
+
+    def test_invalid_style_raises(self, alg):
+        """Unknown style raises ValueError."""
+        with pytest.raises(ValueError):
+            alg.notation.scientific = "invalid"
+
+    def test_non_scientific_unaffected(self, alg):
+        """Normal coefficients are not affected."""
+        e1, _, _ = alg.basis_vectors()
+        assert (0.5 * e1).latex() == "0.5 e_{1}"
+
+    def test_coeff_format_respects_style(self, alg):
+        """coeff_format also uses the notation style."""
+        mv = alg.scalar(1.2e-6)
+        result = mv.latex(coeff_format=".3e")
+        assert r"\times 10^{-6}" in result

--- a/packages/galaga/tests/test_scalar_helpers.py
+++ b/packages/galaga/tests/test_scalar_helpers.py
@@ -187,3 +187,127 @@ class TestScientificNotationStyle:
         mv = alg.scalar(1.2e-6)
         result = mv.latex(coeff_format=".3e")
         assert r"\times 10^{-6}" in result
+
+
+class TestSciLnode:
+    """_sci_lnode produces correct LNode trees for scientific notation."""
+
+    def test_times_style(self):
+        """1.2e-06 → Seq with Sup(10, -6)."""
+        from galaga.algebra import _sci_lnode
+        from galaga.latex_emit import emit
+
+        node = _sci_lnode("1.200e-06", "times")
+        assert emit(node) == r"1.200 \times 10^{-6}"
+
+    def test_cdot_style(self):
+        """1.2e-06 with cdot → \\cdot."""
+        from galaga.algebra import _sci_lnode
+        from galaga.latex_emit import emit
+
+        node = _sci_lnode("1.200e-06", "cdot")
+        assert emit(node) == r"1.200 \cdot 10^{-6}"
+
+    def test_raw_style(self):
+        """raw style passes through unchanged."""
+        from galaga.algebra import _sci_lnode
+        from galaga.latex_emit import emit
+
+        node = _sci_lnode("1.200e-06", "raw")
+        assert emit(node) == "1.200e-06"
+
+    def test_mantissa_one(self):
+        """1e-34 → 10^{-34} (no mantissa)."""
+        from galaga.algebra import _sci_lnode
+        from galaga.latex_emit import emit
+
+        node = _sci_lnode("1e-34", "times")
+        assert emit(node) == "10^{-34}"
+
+    def test_positive_exponent(self):
+        """3e+08 → 3 \\times 10^{8}."""
+        from galaga.algebra import _sci_lnode
+        from galaga.latex_emit import emit
+
+        node = _sci_lnode("3e+08", "times")
+        assert emit(node) == r"3 \times 10^{8}"
+
+    def test_negative_mantissa(self):
+        """-1.2e-06 → -1.2 \\times 10^{-6}."""
+        from galaga.algebra import _sci_lnode
+        from galaga.latex_emit import emit
+
+        node = _sci_lnode("-1.200e-06", "times")
+        assert emit(node) == r"-1.200 \times 10^{-6}"
+
+    def test_non_scientific_passthrough(self):
+        """Plain number passes through as Text."""
+        from galaga.algebra import _sci_lnode
+        from galaga.latex_emit import emit
+
+        node = _sci_lnode("42", "times")
+        assert emit(node) == "42"
+
+    def test_decimal_passthrough(self):
+        """Decimal number passes through as Text."""
+        from galaga.algebra import _sci_lnode
+        from galaga.latex_emit import emit
+
+        node = _sci_lnode("0.5", "times")
+        assert emit(node) == "0.5"
+
+
+class TestCoeffLnode:
+    """_coeff_lnode produces correct LNode trees for coefficient × blade terms."""
+
+    def test_simple_coeff(self):
+        """0.5 e_{1}."""
+        from galaga.algebra import _coeff_lnode
+        from galaga.latex_emit import emit
+
+        node = _coeff_lnode(0.5, "e_{1}", None, "times")
+        assert emit(node) == "0.5 e_{1}"
+
+    def test_unit_coeff_suppressed(self):
+        """Coefficient 1.0 suppressed: e_{1} not 1 e_{1}."""
+        from galaga.algebra import _coeff_lnode
+        from galaga.latex_emit import emit
+
+        node = _coeff_lnode(1.0, "e_{1}", None, "times")
+        assert emit(node) == "e_{1}"
+
+    def test_neg_unit_coeff(self):
+        """Coefficient -1.0: -e_{1}."""
+        from galaga.algebra import _coeff_lnode
+        from galaga.latex_emit import emit
+
+        node = _coeff_lnode(-1.0, "e_{1}", None, "times")
+        assert emit(node) == "-e_{1}"
+
+    def test_scientific_coeff(self):
+        """1.2e-6 e_{1} with \\times."""
+        from galaga.algebra import _coeff_lnode
+        from galaga.latex_emit import emit
+
+        node = _coeff_lnode(1.2e-6, "e_{1}", None, "times")
+        result = emit(node)
+        assert r"\times 10^{-6}" in result
+        assert "e_{1}" in result
+
+    def test_scalar_no_blade(self):
+        """Pure scalar: just the number."""
+        from galaga.algebra import _coeff_lnode
+        from galaga.latex_emit import emit
+
+        node = _coeff_lnode(3.14, "", None, "times")
+        assert emit(node) == "3.14"
+
+    def test_coeff_format(self):
+        """Explicit coeff_format."""
+        from galaga.algebra import _coeff_lnode
+        from galaga.latex_emit import emit
+
+        node = _coeff_lnode(1.2e-6, "e_{1}", ".3e", "times")
+        result = emit(node)
+        assert "1.200" in result
+        assert r"\times 10^{-6}" in result

--- a/uv.lock
+++ b/uv.lock
@@ -502,7 +502,7 @@ wheels = [
 
 [[package]]
 name = "galaga"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "packages/galaga" }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Summary

Replaces the regex-based scientific notation conversion with proper LNode
tree construction. Adds a `Notation.scientific` setting to control the style.

### What changed

- `_sci_lnode()` produces `Sup(Text("10"), Text("-6"))` nodes instead of
  regex string substitution
- `_coeff_lnode()` builds complete coefficient × blade LNode terms
- `Multivector.latex()` builds LNodes per term, emits via pipeline
- `Notation.scientific` property: `"times"` (default), `"cdot"`, or `"raw"`

### Why

The regex was a string-level hack outside the render tree. If new coefficient
formatting paths were added, someone would have to remember to pipe them
through the regex. The LNode approach means any coefficient automatically
gets correct rendering because it goes through the same pipeline.

### Usage

```python
alg.notation.scientific = "cdot"   # 1.2 \cdot 10^{-6}
alg.notation.scientific = "raw"    # 1.2e-06 (debugging)
```

### Stats

- 1427 tests pass (21 new)
- 98% coverage
- ADR-050 documents the approach